### PR TITLE
Deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React component [Maps API 2GIS](https://github.com/2gis/mapsapi)
 
-:construction: WARNING: This package is no longer supported. :construction:
+:construction: WARNING: This package is no longer supported. Please use https://github.com/2gis/mapsapi instead. :construction:
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # React component [Maps API 2GIS](https://github.com/2gis/mapsapi)
 
-[![Travis][build-badge]][build]
-[![npm package][npm-badge]][npm]
-[![Coveralls][coveralls-badge]][coveralls]
+:construction: WARNING: This package is no longer supported. :construction:
 
 ## Installation
 


### PR DESCRIPTION
Пакет нами не поддерживается и не разрабатывается больше двух лет. Люди продолжают приходить и пытаться его использовать. Надо добавить везде уведомление о том, что проект устарел и не будет развиваться.

TODO:
- [x]  Выставить deprecated в npm
- [x] Добавить `DEPRECATED` в описание репозитория
- [x] Добавить информацию в readme
- [x] Удалить упоминание в доке mapsapi https://github.com/2gis/mapsapi/pull/470

Нужно ли что-то еще?